### PR TITLE
Fixed deprecation warning from componentWillMount, componentWillUpdate and componentWillReceiveProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Configuration
 | customIcon             | no           | string, node | undefined                  | Either a string url for an image to use as the icon, or JSX/ReactNode. |
 | placeholder            | no           | string       | undefined                  | If type is input, this is the placeholder for the input field. |
 | show                   | no           | bool         | true                       | If false, the alert will not be rendered. |
-| focusConfirmBtn        | no           | bool         | true                       | If true (and type != input) the comfirm button will receive focus automatically. |
+| focusConfirmBtn        | no           | bool         | true                       | If true (and type != input) the confirm button will receive focus automatically. |
 | required               | no           | bool         | true                       | If true, requires the input field to have a value. |
 | validationMsg          | no           | string       | 'Please enter a response!' | If type is input, this is the message to diplay when the user clicks confirm without entering a value. |
 | validationRegex        | no           | object       | `/^.+$/`                   | Used to validate input value. |
@@ -206,7 +206,6 @@ Configuration
 | disabled               | no           | bool         | false                      | If true, then the confirm button will be disabled. (NOTE: This does not effect the allowEscape prop behavior.)|
 | beforeMount            | no           | func         | noop                       | Hook which is invoked during componentWillMount. |
 | afterMount             | no           | func         | noop                       | Hook which is invoked during componentDidMount. |
-| beforeUpdate           | no           | func         | noop                       | Hook which is invoked during componentWillUpdate. |
 | afterUpdate            | no           | func         | noop                       | Hook which is invoked during componentDidUpdate. |
 | beforeUnmount          | no           | func         | noop                       | Hook which is invoked during componentWillUnmount. |
 | timeout                | no           | number       | 0                          | Call props.onConfirm to close the alert automatically after a certain number of milliseconds. |

--- a/src/components/SweetAlert.tsx
+++ b/src/components/SweetAlert.tsx
@@ -202,7 +202,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     }
 
     this.setState(
-        SweetAlert.setStateFromProps(this.props, this.state)
+        SweetAlert.getStateFromProps(this.props)
     );
 
     this.props.beforeMount();
@@ -218,9 +218,9 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
   }
 
   static getDerivedStateFromProps(nextProps: SweetAlertProps, nextState: SweetAlertState) {
-    if (nextState.type !== SweetAlert.getTypeFromProps(nextProps, nextState.type)) {
+    if (nextState.type !== SweetAlert.getTypeFromProps(nextProps)) {
       return {
-        ...SweetAlert.setStateFromProps(nextProps, nextState), // Set new type and focusConfirmButton
+        ...SweetAlert.getStateFromProps(nextProps), // Set new type and focusConfirmButton
         ...SweetAlert.handleTimeout(nextProps, nextState.timer) // Set new timer
       };
     } else if (nextState.prevTimeout !== nextProps.timeout) {
@@ -259,15 +259,15 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     return null;
   }
 
-  static setStateFromProps = (props: SweetAlertProps, state: SweetAlertState) => {
-    const type = SweetAlert.getTypeFromProps(props, state.type);
+  static getStateFromProps = (props: SweetAlertProps) => {
+    const type = SweetAlert.getTypeFromProps(props);
     return {
       type: type,
       focusConfirmBtn: props.focusConfirmBtn && type !== 'input',
     }
   };
 
-  static getTypeFromProps = (props: SweetAlertProps, stateType: SweetAlertType) => {
+  static getTypeFromProps = (props: SweetAlertProps) => {
     if (props.type) return props.type;
     if (props.secondary) return 'secondary';
     if (props.info) return 'info';
@@ -276,7 +276,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     if (props.danger || props.error) return 'danger';
     if (props.input) return 'input';
     if (props.custom) return 'custom';
-    return stateType;
+    return 'default';
   };
 
   unsupportedProp = (oldProp: string, message: string) => {

--- a/src/components/SweetAlert.tsx
+++ b/src/components/SweetAlert.tsx
@@ -186,7 +186,8 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     timer: null,
   };
 
-  componentWillMount() {
+  constructor(props: SweetAlertProps) {
+    super(props);
 
     if (this.props.beforeUpdate) {
       this.unsupportedProp('beforeUpdate', 'use props.afterUpdate');

--- a/src/components/SweetAlert.tsx
+++ b/src/components/SweetAlert.tsx
@@ -159,7 +159,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     showCloseButton     : false,
     beforeMount         : () => {},
     afterMount          : () => {},
-    beforeUpdate        : () => {},
+    beforeUpdate        : null,
     afterUpdate         : () => {},
     beforeUnmount       : () => {},
     style               : {},
@@ -187,6 +187,11 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
   };
 
   componentWillMount() {
+
+    if (this.props.beforeUpdate) {
+      this.unsupportedProp('beforeUpdate', 'use props.afterUpdate');
+    }
+
     if (this.props.defaultValue != null) {
       this.setState({
         inputValue: this.props.defaultValue
@@ -213,11 +218,10 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     }
   }
 
-  componentWillUpdate(nextProps: SweetAlertProps, nextState: SweetAlertProps) {
-    this.props.beforeUpdate(nextProps, nextState);
-  }
-
   componentDidUpdate(prevProps: SweetAlertProps, prevState: SweetAlertProps) {
+    if(this.props.beforeUpdate)
+      this.props.beforeUpdate(prevProps, prevState);
+
     this.props.afterUpdate(prevProps, prevState);
   }
 

--- a/src/demo/src/examples/Timer.tsx
+++ b/src/demo/src/examples/Timer.tsx
@@ -1,0 +1,11 @@
+import {Example} from "./Example";
+
+const title: string = "A success message, with a close timer";
+
+const snippet: string = `
+<SweetAlert success title="Success Data!" onConfirm={this.onConfirm} timeout={2000}>
+  This success message will automatically close after 2 seconds
+</SweetAlert>
+`;
+
+export default new Example(title, snippet);

--- a/src/demo/src/examples/index.ts
+++ b/src/demo/src/examples/index.ts
@@ -9,6 +9,7 @@ import Password from "./Password";
 import Success from "./Success";
 import TitleWithText from "./TitleWithText";
 import WarningWithCallbacks from "./WarningWithCallbacks";
+import Timer from "./Timer";
 
 export const examples: Example[] = [
   Basic,
@@ -21,4 +22,5 @@ export const examples: Example[] = [
   Password,
   CustomStyle,
   LongMessage,
+  Timer,
 ];


### PR DESCRIPTION
Fixed deprecation warning from componentWillMount, componentWillUpdate and componentWillReceiveProps function in React. Fixed implementations of what these used to do to the new functions. Deprecated beforeUpdate property in favour of afterUpdate. 
Updated demo page with timer example, and updated the readme with the changes in this PR.

Source where I got the updates and changes from: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

Fixes #48