### PR TITLE
Button actions Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,15 @@ Configuration
 | cancelBtnCssClass      | no           | string       | ''                         | CSS class added to cancel button. |
 | cancelBtnStyle         | no           | object       | {}                         | Inline style added to cancel button. |
 | showCloseButton        | no           | bool         | false                      | If set to true, then an X close button will be shown in the top right of the alert. |
+| reverseButtons         | no           | bool         | false                      | Reverses the order of the buttons. |
+| customActions          | no           | string, node | undefined                  | Custom action buttons. Can make more than 2 action buttons or full custom style. JSX/ReactNode allowed. |
 | customIcon             | no           | string, node | undefined                  | Either a string url for an image to use as the icon, or JSX/ReactNode. |
 | placeholder            | no           | string       | undefined                  | If type is input, this is the placeholder for the input field. |
 | show                   | no           | bool         | true                       | If false, the alert will not be rendered. |
 | focusConfirmBtn        | no           | bool         | true                       | If true (and type != input) the comfirm button will receive focus automatically. |
+| focusCancelBtn         | no           | bool         | true                       | If true (and type != input) the cancel button will receive focus automatically. |
 | required               | no           | bool         | true                       | If true, requires the input field to have a value. |
-| validationMsg          | no           | string       | 'Please enter a response!' | If type is input, this is the message to diplay when the user clicks confirm without entering a value. |
+| validationMsg          | no           | string       | 'Please enter a response!' | If type is input, this is the message to display when the user clicks confirm without entering a value. |
 | validationRegex        | no           | object       | `/^.+$/`                   | Used to validate input value. |
 | defaultValue           | no           | string       | undefined                  | If type is input, this is the default value for the input field. |
 | inputType              | no           | string       | 'text'                     | If type is input, this is the input type (text, textarea, password, number, etc...) |

--- a/src/components/Buttons.tsx
+++ b/src/components/Buttons.tsx
@@ -17,6 +17,7 @@ export default class Buttons extends React.Component<SweetAlertProps> {
     focusConfirmBtn: true,
     showConfirm: true,
     showCancel: false,
+    reverseButtons: false,
     btnSize: 'lg',
   };
 
@@ -99,56 +100,78 @@ export default class Buttons extends React.Component<SweetAlertProps> {
     return this.buttonStyles[bsStyle];
   };
 
+
+  confirmButtonRender() {
+    if(!this.props.showConfirm)
+      return false;
+
+    const confirmBtnBsStyle = this.props.confirmBtnBsStyle === 'error' ? 'danger' : this.props.confirmBtnBsStyle;
+    const confirmButtonStyle = Object.assign(
+        {},
+        styles.button,
+        this.getButtonStyle(confirmBtnBsStyle),
+        this.props.confirmBtnStyle || {}
+    );
+
+    return (
+        <span>
+            <button
+                ref={this.setConfirmButtonElementRef}
+                disabled={this.props.disabled}
+                style={confirmButtonStyle}
+                className={`btn btn-${this.props.btnSize} btn-${confirmBtnBsStyle} ${this.props.confirmBtnCssClass}`}
+                onClick={() => this.props.onConfirm()}
+                type="button"
+            >
+                {this.props.confirmBtnText}
+            </button>
+        </span>
+    );
+  }
+
+  cancelButtonRender() {
+    if(!this.props.showCancel)
+      return false;
+
+    const cancelBtnBsStyle = this.props.cancelBtnBsStyle === 'error' ? 'danger' : this.props.cancelBtnBsStyle;
+    const cancelButtonStyle = Object.assign(
+        {},
+        styles.button,
+        this.props.cancelBtnStyle || {}
+    );
+
+    return (
+        <span>
+            <button
+                style={cancelButtonStyle}
+                className={`btn btn-${this.props.btnSize} btn-${cancelBtnBsStyle} ${this.props.cancelBtnCssClass}`}
+                onClick={() => this.props.onCancel()}
+                type="button"
+            >
+                { this.props.cancelBtnText }
+            </button>
+        </span>
+    );
+  }
+
   render() {
     if (!this.props.showConfirm && !this.props.showCancel) {
       return false;
     }
 
-    const cancelBtnBsStyle = this.props.cancelBtnBsStyle === 'error' ? 'danger' : this.props.cancelBtnBsStyle;
-    const confirmBtnBsStyle = this.props.confirmBtnBsStyle === 'error' ? 'danger' : this.props.confirmBtnBsStyle;
-
-    const cancelButtonStyle = Object.assign(
-      {},
-      styles.button,
-      this.props.cancelBtnStyle || {}
-    );
-
-    const confirmButtonStyle = Object.assign(
-      {},
-      styles.button,
-      this.getButtonStyle(confirmBtnBsStyle),
-      this.props.confirmBtnStyle || {}
-    );
-
     return (
       <p style={actionsStyle}>
-
-        {this.props.showCancel && (
-          <span>
-            <button
-              style={cancelButtonStyle}
-              className={`btn btn-${this.props.btnSize} btn-${cancelBtnBsStyle} ${this.props.cancelBtnCssClass}`}
-              onClick={() => this.props.onCancel()}
-              type="button"
-            >
-              {this.props.cancelBtnText}
-            </button>
-          </span>
-        )}
-        {this.props.showConfirm && (
-          <span>
-            <button
-              ref={this.setConfirmButtonElementRef}
-              disabled={this.props.disabled}
-              style={confirmButtonStyle}
-              className={`btn btn-${this.props.btnSize} btn-${confirmBtnBsStyle} ${this.props.confirmBtnCssClass}`}
-              onClick={() => this.props.onConfirm()}
-              type="button"
-            >
-              {this.props.confirmBtnText}
-            </button>
-        </span>
-        )}
+            { !this.props.reverseButtons ? (
+              <React.Fragment>
+                {this.cancelButtonRender()}
+                {this.confirmButtonRender()}
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                {this.confirmButtonRender()}
+                {this.cancelButtonRender()}
+              </React.Fragment>
+            ) }
       </p>
     );
   }

--- a/src/components/Buttons.tsx
+++ b/src/components/Buttons.tsx
@@ -161,6 +161,10 @@ export default class Buttons extends React.Component<SweetAlertProps> {
 
     return (
       <p style={actionsStyle}>
+        { this.props.customActions? (
+            this.props.customActions
+        ) : (
+          <React.Fragment>
             { !this.props.reverseButtons ? (
               <React.Fragment>
                 {this.cancelButtonRender()}
@@ -172,6 +176,8 @@ export default class Buttons extends React.Component<SweetAlertProps> {
                 {this.cancelButtonRender()}
               </React.Fragment>
             ) }
+          </React.Fragment>
+        ) }
       </p>
     );
   }

--- a/src/components/Buttons.tsx
+++ b/src/components/Buttons.tsx
@@ -15,6 +15,7 @@ export default class Buttons extends React.Component<SweetAlertProps> {
     cancelBtnCssClass: '',
     cancelBtnStyle: {},
     focusConfirmBtn: true,
+    focusCancelBtn: false,
     showConfirm: true,
     showCancel: false,
     reverseButtons: false,
@@ -54,6 +55,7 @@ export default class Buttons extends React.Component<SweetAlertProps> {
 
   private buttonStyles = {};
   private confirmButtonElement: HTMLButtonElement = null;
+  private cancelButtonElement: HTMLButtonElement = null;
 
   componentDidMount() {
     this.focusButton();
@@ -77,9 +79,18 @@ export default class Buttons extends React.Component<SweetAlertProps> {
   setConfirmButtonElementRef = (element: HTMLButtonElement) => {
     this.confirmButtonElement = element;
   };
+  setCancelButtonElementRef = (element: HTMLButtonElement) => {
+    this.cancelButtonElement = element;
+  };
 
   focusButton() {
-    if (this.props.focusConfirmBtn && this.confirmButtonElement) {
+    if(this.props.focusCancelBtn && this.cancelButtonElement) {
+      try {
+        this.cancelButtonElement.focus();
+      } catch (e) {
+        // whoops
+      }
+    } else if (this.props.focusConfirmBtn && this.confirmButtonElement) {
       try {
         this.confirmButtonElement.focus();
       } catch (e) {
@@ -143,6 +154,7 @@ export default class Buttons extends React.Component<SweetAlertProps> {
     return (
         <span>
             <button
+                ref={this.setCancelButtonElementRef}
                 style={cancelButtonStyle}
                 className={`btn btn-${this.props.btnSize} btn-${cancelBtnBsStyle} ${this.props.cancelBtnCssClass}`}
                 onClick={() => this.props.onCancel()}

--- a/src/components/SweetAlert.tsx
+++ b/src/components/SweetAlert.tsx
@@ -75,6 +75,7 @@ export interface SweetAlertOptionalProps extends  SweetAlertOptionalPropsWithDef
   defaultValue?: string,
   showConfirm?: boolean,
   showCancel?: boolean,
+  customActions?: React.ReactNode|string,
 }
 
 export interface SweetAlertProps extends SweetAlertOptionalProps {
@@ -144,6 +145,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     beforeUnmount: PropTypes.func,
     timeout: PropTypes.number,
     reverseButtons: PropTypes.bool,
+    customActions: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   };
 
   static defaultProps: SweetAlertOptionalPropsWithDefaults = {

--- a/src/components/SweetAlert.tsx
+++ b/src/components/SweetAlert.tsx
@@ -42,6 +42,7 @@ export interface SweetAlertOptionalPropsWithDefaults {
   style?: CSSProperties;
   closeBtnStyle?: CSSProperties;
   timeout?: number;
+  reverseButtons?: boolean;
 }
 
 export type SweetAlertType = 'default'|'secondary'|'info'|'success'|'warning'|'danger'|'error'|'input'|'custom';
@@ -142,6 +143,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     afterUpdate: PropTypes.func,
     beforeUnmount: PropTypes.func,
     timeout: PropTypes.number,
+    reverseButtons: PropTypes.bool,
   };
 
   static defaultProps: SweetAlertOptionalPropsWithDefaults = {
@@ -165,6 +167,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     style               : {},
     closeBtnStyle       : {},
     timeout             : 0,
+    reverseButtons      : false,
   };
 
   static SuccessIcon = SuccessIcon;

--- a/src/components/SweetAlert.tsx
+++ b/src/components/SweetAlert.tsx
@@ -33,6 +33,7 @@ export interface SweetAlertOptionalPropsWithDefaults {
   required?: boolean;
   disabled?: boolean;
   focusConfirmBtn?: boolean;
+  focusCancelBtn?: boolean;
   showCloseButton?: boolean;
   beforeMount?: Function;
   afterMount?: Function;
@@ -88,6 +89,7 @@ type SweetAlertPropsTypes = { [key in keyof SweetAlertProps]: any };
 export interface SweetAlertState {
   type?: SweetAlertType;
   focusConfirmBtn?: boolean;
+  focusCancelBtn?: boolean;
   inputValue?: string;
   showValidationMessage?: boolean;
   timer?: any;
@@ -138,6 +140,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     hideOverlay: PropTypes.bool,
     disabled: PropTypes.bool,
     focusConfirmBtn: PropTypes.bool,
+    focusCancelBtn: PropTypes.bool,
     beforeMount: PropTypes.func,
     afterMount: PropTypes.func,
     beforeUpdate: PropTypes.func,
@@ -160,6 +163,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     required            : true,
     disabled            : false,
     focusConfirmBtn     : true,
+    focusCancelBtn      : false,
     showCloseButton     : false,
     beforeMount         : () => {},
     afterMount          : () => {},
@@ -186,6 +190,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
   state: SweetAlertState = {
     type: 'default',
     focusConfirmBtn: true,
+    focusCancelBtn: false,
     inputValue: '',
     showValidationMessage: false,
     timer: null,
@@ -251,6 +256,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
     this.setState({
       type,
       focusConfirmBtn: props.focusConfirmBtn && type !== 'input',
+      focusCancelBtn: props.focusCancelBtn && type !== 'input',
     });
   };
 
@@ -419,6 +425,7 @@ export default class SweetAlert extends React.Component<SweetAlertProps, SweetAl
               type={this.state.type}
               onConfirm={this.onConfirm}
               focusConfirmBtn={this.state.focusConfirmBtn}
+              focusCancelBtn={this.state.focusCancelBtn}
             />
 
           </div>

--- a/src/demo/src/examples/CustomButtons.tsx
+++ b/src/demo/src/examples/CustomButtons.tsx
@@ -1,0 +1,22 @@
+import {Example} from "./Example";
+
+const title: string = "Custom Actions";
+
+const snippet: string = `
+<SweetAlert 
+    success 
+    title="Success Data!" 
+    onConfirm={this.onConfirm} 
+    customActions={
+        <React.Fragment>
+            <button onClick={this.onCancel}>Cancel</button>
+            <button onClick={this.onConfirm}>Info</button>
+            <button onClick={this.onConfirm}>Confirm</button>
+        </React.Fragment>
+    }
+>
+  A message with custom actions!
+</SweetAlert>
+`;
+
+export default new Example(title, snippet);

--- a/src/demo/src/examples/WarningWithCallbacks.tsx
+++ b/src/demo/src/examples/WarningWithCallbacks.tsx
@@ -12,6 +12,8 @@ const snippet: string = `
   title="Are you sure?"
   onConfirm={this.deleteFile}
   onCancel={this.onCancel}
+  reverseButtons
+  focusCancelBtn
 >
   You will not be able to recover this imaginary file!
 </SweetAlert>

--- a/src/demo/src/examples/index.ts
+++ b/src/demo/src/examples/index.ts
@@ -9,6 +9,7 @@ import Password from "./Password";
 import Success from "./Success";
 import TitleWithText from "./TitleWithText";
 import WarningWithCallbacks from "./WarningWithCallbacks";
+import CustomButtons from "./CustomButtons";
 
 export const examples: Example[] = [
   Basic,
@@ -21,4 +22,5 @@ export const examples: Example[] = [
   Password,
   CustomStyle,
   LongMessage,
+  CustomButtons,
 ];


### PR DESCRIPTION
Added `focusCancelBtn` property that focuses on the cancel button by default.
Added `reverseButtons` property that reverses the cancel and confirm button order.
Added `customActions` property that overrides the buttons in the alert message. In here it would be possible to create more buttons or add some custom behaviour.

I also updated the readme documentation with these changes and added and updated a example with these features.

Closes #42 
Closes #34