### PR TITLE
Added custom show and hide animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Configuration
 | afterUpdate            | no           | func         | noop                       | Hook which is invoked during componentDidUpdate. |
 | beforeUnmount          | no           | func         | noop                       | Hook which is invoked during componentWillUnmount. |
 | timeout                | no           | number       | 0                          | Call props.onConfirm to close the alert automatically after a certain number of milliseconds. |
+| openAnim               | no           | bool, object | {name: "showSweetAlert", duration: 300} | Set a custom show animation or false to have no animation. To specify a custom animation you set the name to your css animation and duration to the animation duration in milliseconds. |
+| closeAnim              | no           | bool, object | false                       | Set a custom hide animation or false to have no animation. To specify a custom animation you set the name to your css animation and duration to the animation duration in milliseconds. |
 
 Related projects
 ----------------

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Configuration
 | beforeUnmount          | no           | func         | noop                       | Hook which is invoked during componentWillUnmount. |
 | timeout                | no           | number       | 0                          | Call props.onConfirm to close the alert automatically after a certain number of milliseconds. |
 | openAnim               | no           | bool, object | {name: "showSweetAlert", duration: 300} | Set a custom show animation or false to have no animation. To specify a custom animation you set the name to your css animation and duration to the animation duration in milliseconds. |
-| closeAnim              | no           | bool, object | false                       | Set a custom hide animation or false to have no animation. To specify a custom animation you set the name to your css animation and duration to the animation duration in milliseconds. |
+| closeAnim              | no           | bool, object | false                       | Set a custom hide animation or false to have no animation. To specify a custom animation you set the name to your css animation and duration to the animation duration in milliseconds. For a simple hide animation you could use `{name: "hideSweetAlert", duration: 100}` |
 
 Related projects
 ----------------

--- a/src/css/animations.css
+++ b/src/css/animations.css
@@ -40,8 +40,8 @@
     -webkit-transform: scale(1);
   }
   100% {
-    transform: scale(0.5);
-    -webkit-transform: scale(0.5);
+    transform: scale(0.4);
+    -webkit-transform: scale(0.4);
   }
 }
 @keyframes hideSweetAlert {
@@ -50,8 +50,8 @@
     -webkit-transform: scale(1);
   }
   100% {
-    transform: scale(0.5);
-    -webkit-transform: scale(0.5);
+    transform: scale(0.4);
+    -webkit-transform: scale(0.4);
   }
 }
 @-webkit-keyframes animateSuccessTip {

--- a/src/demo/src/Demo.tsx
+++ b/src/demo/src/Demo.tsx
@@ -15,6 +15,7 @@ window.SweetAlert = SweetAlert;
 
 interface DemoState {
 	alert: React.ReactNode;
+	showAnimExample: boolean;
 	textareaValue: string;
 }
 
@@ -32,6 +33,7 @@ export default class Demo extends React.Component<{}, DemoState> {
 
 	state: DemoState = {
 		alert: null,
+		showAnimExample: false,
 		textareaValue: defaultTextAreaValue,
 	};
 
@@ -113,7 +115,7 @@ export default class Demo extends React.Component<{}, DemoState> {
 		}
 	};
 
-	hideAlert = () => this.setState({ alert: null });
+	hideAlert = () => this.setState({ alert: null, showAnimExample: false });
 	onConfirm = () => this.hideAlert();
 	onCancel = () => this.hideAlert();
 
@@ -293,6 +295,28 @@ export default class Demo extends React.Component<{}, DemoState> {
 						</div>
 					))}
 
+					<div>
+						<h4>Hide Animation</h4>
+						<Row>
+							<Col sm={2} className="text-center">
+								<p>
+									<Button bsStyle="primary" onClick={() => this.setState({showAnimExample: true})} >
+										Try It
+									</Button>
+								</p>
+							</Col>
+							<Col sm={10}>
+								<pre>{"<SweetAlert show={this.state.showAnimExample} \n" +
+								"  title=\"Here's a message!\"\n" +
+								"  closeAnim={{name: \"hideSweetAlert\", duration: 100}}\n" +
+								"  onConfirm={() => this.hideAlert()}\n" +
+								">\n" +
+								"  Just close the SweetAlert to see the hide animation\n" +
+								"<SweetAlert/>"}</pre>
+							</Col>
+						</Row>
+					</div>
+
 				</div>
 
 			    <footer>
@@ -300,6 +324,14 @@ export default class Demo extends React.Component<{}, DemoState> {
 			        <li><a href="http://github.com/djorg83"><i className="fa fa-github" /> GitHub</a></li>
 			      </ul>
 			    </footer>
+
+				<SweetAlert show={this.state.showAnimExample}
+							title="Here's a message!"
+							closeAnim={{name: "hideSweetAlert", duration: 100}}
+							onConfirm={() => this.hideAlert()}
+				>
+					Just close the SweetAlert to see the hide animation
+				</SweetAlert>
 
 			    {this.state.alert}
 			</div>

--- a/src/styles/SweetAlertStyles.ts
+++ b/src/styles/SweetAlertStyles.ts
@@ -36,7 +36,6 @@ export const sweetAlert: CSSProperties = {
   borderRadius: ".3125em",
   textAlign: "center",
   position: "relative",
-  animation: "showSweetAlert 0.3s",
   flexDirection: "column",
   justifyContent: "center",
   maxWidth: "100%",


### PR DESCRIPTION
Added support for custom show and hide animations with the `openAnim` and `closeAnim` properties. 
I also added an example in the demo page with a hide animation and I updated the readme documentation with these new properties.

This implements the feature request in issue #18.

To add a custom animation just pass an object with the name and duration properties in the open or close Anim property. In the name property, you specify the CSS animation-name and the duration is the animation duration in ms. 
If setting `openAnim` and/or `closeAnim` property to false, there will not be an animation.

Closes #18